### PR TITLE
Account data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# UNL_CAS module
+
+This module does the following
+* allows users to log in via UNL CAS
+* allows searching and importing users into the system
+* stores UNL information, such as the 'eduPersonAffiliation', to help with access restrictions
+
+## Why LDAP as a source of user information instead of directory.unl.edu?
+LDAP gives us access to users that have their privacy flag set. This is important so that we can add any users to sites regardless of weather or not their privacy flag is set.
+
+Note that we use directory.unl.edu as a backup source of information in the case that either LDAP is down or the LDAP credentials are not provides/bad.
+
+
+## Getting and setting UNL user data
+UNL Specific user data is retrieved when an account is first created. Every login there-after will trigger an update, but it may not happen right away.
+
+To manually update user data:
+```
+$helper = new Helper();
+$user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+$helper->updateUserData($user);
+```
+
+To retrieve user data
+```
+/**
+* @var UserDataInterface $userDataService
+*/
+$userDataService = \Drupal::service('user.data');
+
+//Specific field
+$primaryAffiliation = $userDataService->get('unl_cas', \Drupal::currentUser()->id(), 'primaryAffiliation');
+
+//All UNL user data
+$allUserData = $userDataService->get('unl_cas', \Drupal::currentUser()->id());
+
+```

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
       "homepage": "https://www.drupal.org/u/ericras",
       "role": "Maintainer"
     }
-  ]
+  ],
+  "require":{
+    "symfony/ldap": "~3.2.1"
+  }
 }

--- a/src/Controller/UnlCasController.php
+++ b/src/Controller/UnlCasController.php
@@ -5,6 +5,7 @@ namespace Drupal\unl_cas\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\Core\Url;
+use Drupal\unl_cas\Helper;
 use Drupal\user\Entity\User;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -69,8 +70,10 @@ class UnlCasController extends ControllerBase {
     $auth = $cas->validateTicket();
 
     if ($auth) {
+      $helper = new Helper();
+      
       $username = $cas->getUsername();
-      $user = $this->importUser($username);
+      $user = $helper->importUser($username);
 
       if (\Drupal::currentUser()->id() != $user->id()) {
         \Drupal::currentUser()->setAccount($user);
@@ -93,20 +96,5 @@ class UnlCasController extends ControllerBase {
     
     //The controller expects a response object or a render array
     return new RedirectResponse(Url::fromUserInput('/'.$destination['destination'])->toString());
-  }
-
-  public function importUser($username) {
-    $username = trim($username);
-    $user = user_load_by_name($username);
-    if (!$user) {
-      $user = \Drupal\user\Entity\User::create();
-      $user->setUsername($username);
-      $user->setEmail($username . '@unl.edu');
-      $user->setPassword('Trump');
-      $user->enforceIsNew();
-      $user->activate();
-    }
-    $user->save();
-    return $user;
   }
 }

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -56,11 +56,11 @@ class SettingsForm extends ConfigFormBase {
     //indicate whether or not LDAP is working
     $query = new PersonDataQuery();
     $result = $query->getUserData(\Drupal::currentUser()->getAccountName());
+    $affiliation = \Drupal::service('user.data')->get('unl_cas', \Drupal::currentUser()->id(), 'primaryAffiliation');
 
     if (!$result || $result['data']['unl']['source'] !== PersonDataQuery::SOURCE_LDAP) {
-      drupal_set_message($this->t('LDAP is NOT being used. Please ensure credentials are correct.'), 'warning');
+      drupal_set_message($this->t('LDAP is NOT being used. Please ensure credentials are correct. Your primary affiliation is: @affiliation', ['@affiliation'=>$affiliation]), 'warning');
     } else {
-      $affiliation = \Drupal::service('user.data')->get('unl_cas', \Drupal::currentUser()->id(), 'primaryAffiliation');
       drupal_set_message($this->t('LDAP is being used, your primary affiliation is: @affiliation', ['@affiliation'=>$affiliation]));
     }
     

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -4,6 +4,7 @@ namespace Drupal\unl_cas\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\unl_cas\PersonDataQuery;
 
 /**
  * Configures unl_cas settings for this site.
@@ -52,6 +53,17 @@ class SettingsForm extends ConfigFormBase {
         '#required' => TRUE,
     );
 
+    //indicate whether or not LDAP is working
+    $query = new PersonDataQuery();
+    $result = $query->getUserData(\Drupal::currentUser()->getAccountName());
+
+    if (!$result || $result['data']['unl']['source'] !== PersonDataQuery::SOURCE_LDAP) {
+      drupal_set_message($this->t('LDAP is NOT being used. Please ensure credentials are correct.'), 'warning');
+    } else {
+      $affiliation = \Drupal::service('user.data')->get('unl_cas', \Drupal::currentUser()->id(), 'primaryAffiliation');
+      drupal_set_message($this->t('LDAP is being used, your primary affiliation is: @affiliation', ['@affiliation'=>$affiliation]));
+    }
+    
     return parent::buildForm($form, $form_state);
   }
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -77,5 +77,7 @@ class Helper
     }
 
     $userDataService->set('unl_cas', $user->id(), 'last-update', time());
+    
+    return true;
   }
 }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -22,7 +22,7 @@ class Helper
    *
    * @return bool|\Drupal\Core\Entity\EntityInterface|object|static
    */
-  public function importUser($username) {
+  public function initializeUser($username) {
     $username = trim($username);
     $user = user_load_by_name($username);
     if (!$user) {

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -31,12 +31,11 @@ class Helper
       $user->setEmail($username . '@unl.edu');
       $user->enforceIsNew();
       $user->activate();
+      $user->save();
+
+      //The first time that they log in, try to update userdata
+      $this->updateUserData($user);
     }
-    
-    $user->save();
-    
-    //The first time that they log in, try to update userdata
-    $this->updateUserData($user);
     
     return $user;
   }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\unl_cas;
+use Drupal\user\Entity\User;
+use Drupal\user\UserDataInterface;
+
+/**
+ * Configures unl_cas settings for this site.
+ */
+class Helper
+{
+
+  function __construct()
+  {
+    //nothing to do here
+  }
+
+  /**
+   * Import a UNL user into the system and return the drupal User object
+   *
+   * @param $username
+   *
+   * @return bool|\Drupal\Core\Entity\EntityInterface|object|static
+   */
+  public function importUser($username) {
+    $username = trim($username);
+    $user = user_load_by_name($username);
+    if (!$user) {
+      $user = User::create();
+      $user->setUsername($username);
+      $user->setEmail($username . '@unl.edu');
+      $user->enforceIsNew();
+      $user->activate();
+    }
+    
+    $user->save();
+    
+    //The first time that they log in, try to update userdata
+    $this->updateUserData($user);
+    
+    return $user;
+  }
+
+  /**
+   * Update custom UNL specific user data for a given user.
+   * 
+   * Updating a user would look something like this:
+   * $helper = new Helper();
+   * $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+   * $helper->updateUserData($user);
+   * 
+   * @param User $user
+   *
+   * @return bool
+   */
+  public function updateUserData(User $user)
+  {
+    $query = new PersonDataQuery();
+    $data = $query->getUserData($user->getAccountName());
+    
+    if (!$data) {
+      //No data to be found
+      return false;
+    }
+    
+    //Update the email address
+    $user->setEmail($data['mail']);
+    $user->save();
+
+    /**
+     * @var UserDataInterface $userDataService
+     */
+    $userDataService = \Drupal::service('user.data');
+
+    foreach ($data['data']['unl'] as $key=>$value) {
+      $userDataService->set('unl_cas', $user->id(), $key, $value);
+    }
+
+    $userDataService->set('unl_cas', $user->id(), 'last-update', time());
+  }
+}

--- a/src/PersonDataQuery.php
+++ b/src/PersonDataQuery.php
@@ -52,6 +52,7 @@ class PersonDataQuery
 
   /**
    * @return Ldap
+   * @throws \Exception
    */
   protected function getClient() {
     static $client;
@@ -61,6 +62,15 @@ class PersonDataQuery
     }
     
     $config = \Drupal::config('unl_cas.settings');
+    
+    if (empty($config->get('dn'))) {
+      throw new \Exception('the DN is not set, we will be unable to connect to LDAP');
+    }
+
+    if (empty($config->get('password'))) {
+      throw new \Exception('the password is not set, we will be unable to connect to LDAP');
+    }
+    
     $adapter = new Adapter([
       'connection_string' => $config->get('uri'),
       'version' => 3,

--- a/src/PersonDataQuery.php
+++ b/src/PersonDataQuery.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\unl_cas;
+use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
+use Symfony\Component\Ldap\Ldap;
+
+/**
+ * Configures unl_cas settings for this site.
+ */
+class PersonDataQuery
+{
+  const SOURCE_LDAP = 'ldap';
+  const SOURCE_DIRECTORY = 'directory.unl.edu';
+  
+  function __construct() {
+    //nothing to do here
+  }
+  
+  public function getUserData($username) {
+    $result = false;
+    
+    // First, try getting the info from LDAP.
+    try {
+      $client = $this->getClient();
+      $query = $client->query('dc=unl,dc=edu', 'uid=' . $client->escape($username));
+      $results = $query->execute();
+      if (count($results) > 0) {
+        $result = $results[0]->getAttributes();
+        $result['data-source'] = self::SOURCE_LDAP;
+      }
+    }
+    catch (\Exception $e) {
+      // don't do anything, just go on to try the PeopleFinder method
+    }
+
+    // Next, if LDAP didn't work, try PeopleFinder service.
+    if (!$result) {
+      $json = file_get_contents('https://directory.unl.edu/service.php?format=json&uid=' . $username);
+      if ($json) {
+        $result = json_decode($json, TRUE);
+        $result['data-source'] = self::SOURCE_DIRECTORY;
+      }
+    }
+    
+    if ($result) {
+      return $this->sanitizeUserRecordData($result);
+    }
+
+    //Return the false value
+    return $result;
+  }
+
+  /**
+   * @return Ldap
+   */
+  protected function getClient() {
+    static $client;
+    
+    if ($client !== null) {
+      return $client;
+    }
+    
+    $config = \Drupal::config('unl_cas.settings');
+    $adapter = new Adapter([
+      'connection_string' => $config->get('uri'),
+      'version' => 3,
+    ]);
+    $client = new Ldap($adapter);
+    $client->bind($config->get('dn'), $config->get('password'));
+    
+    return $client;
+  }
+
+  /**
+   * Sanitize a user record data that was retrieved from either LDAP or directory
+   * 
+   * @param array $data
+   *
+   * @return array
+   */
+  public function sanitizeUserRecordData(array $data) {
+    $userData = [
+      'uid'     => '',
+      'mail'     => '',
+      'data'     => [
+        'unl' => [
+          'fullName'           => '',
+          'affiliations'       => '',
+          'primaryAffiliation' => '',
+          'department'         => '',
+          'major'              => '',
+          'studentStatus'      => [],
+          'source'             => '',
+        ]
+      ],
+    ];
+
+    // If either LDAP or PeopleFinder found data, use it.
+    if (!empty($data)) {
+      $result = array_change_key_case($data, CASE_LOWER);
+      
+      $userData['data']['unl'] = [
+        'fullName'           => (isset($result['edupersonnickname']) ? $result['edupersonnickname'][0] : $result['givenname'][0]) . ' ' . $result['sn'][0],
+        'affiliations'       => $result['edupersonaffiliation'],
+        'primaryAffiliation' => $result['edupersonprimaryaffiliation'][0],
+        'department'         => (isset($result['unlhrprimarydepartment']) ? $result['unlhrprimarydepartment'][0] : ''),
+        'major'              => (isset($result['unlsismajor']) ? $result['unlsismajor'][0] : ''),
+        'studentStatus'      => (isset($result['unlsisstudentstatus']) ? $result['unlsisstudentstatus'] : []),
+        'source'             => $data['data-source'],
+      ];
+      
+      if (is_array($data['uid'])) {
+        //ldap DOES return an array
+        $userData['uid'] = $result['uid'][0];
+      } else {
+        //directory does not return an array
+        $userData['uid'] = $result['uid'];
+      }
+
+      if ($result['mail'][0]) {
+        $userData['mail'] = $result['mail'][0];
+      } else {
+        //No email found, use a default one
+        $userData['mail'] = $userData['uid'].'@unl.edu';
+      }
+    }
+
+    return $userData;
+  }
+}

--- a/src/PersonDataQuery.php
+++ b/src/PersonDataQuery.php
@@ -64,11 +64,15 @@ class PersonDataQuery
     $config = \Drupal::config('unl_cas.settings');
     
     if (empty($config->get('dn'))) {
-      throw new \Exception('the DN is not set, we will be unable to connect to LDAP');
+      throw new \Exception('the LDAP DN is not set, we will be unable to connect to LDAP');
     }
 
     if (empty($config->get('password'))) {
-      throw new \Exception('the password is not set, we will be unable to connect to LDAP');
+      throw new \Exception('the LDAP password is not set, we will be unable to connect to LDAP');
+    }
+
+    if (empty($config->get('uri'))) {
+      throw new \Exception('the LDAP uri is not set, we will be unable to connect to LDAP');
     }
     
     $adapter = new Adapter([

--- a/src/Plugin/QueueWorker/UpdateUserDataCron.php
+++ b/src/Plugin/QueueWorker/UpdateUserDataCron.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\unl_cas\Plugin\QueueWorker;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\unl_cas\Helper;
+use Drupal\user\Entity\User;
+
+/**
+ * A Queue worker that updates user data.
+ *
+ * @QueueWorker(
+ *   id = "cron_unl_cas_update_user_data",
+ *   title = @Translation("unl_cas update user data"),
+ *   cron = {"time" = 60}
+ * )
+ */
+class UpdateUserDataCron extends QueueWorkerBase
+{
+
+  /**
+   * Works on a single queue item.
+   *
+   * @param mixed $data
+   *   The data that was passed to
+   *   \Drupal\Core\Queue\QueueInterface::createItem() when the item was queued.
+   *
+   * @throws \Drupal\Core\Queue\RequeueException
+   *   Processing is not yet finished. This will allow another process to claim
+   *   the item immediately.
+   * @throws \Exception
+   *   A QueueWorker plugin may throw an exception to indicate there was a
+   *   problem. The cron process will log the exception, and leave the item in
+   *   the queue to be processed again later.
+   * @throws \Drupal\Core\Queue\SuspendQueueException
+   *   More specifically, a SuspendQueueException should be thrown when a
+   *   QueueWorker plugin is aware that the problem will affect all subsequent
+   *   workers of its queue. For example, a callback that makes HTTP requests
+   *   may find that the remote server is not responding. The cron process will
+   *   behave as with a normal Exception, and in addition will not attempt to
+   *   process further items from the current item's queue during the current
+   *   cron run.
+   *
+   * @see \Drupal\Core\Cron::processQueues()
+   */
+  public function processItem($data)
+  {
+    if (!isset($data->uid)) {
+      return;
+    }
+    
+    $helper = new Helper();
+    $user = User::load($data->uid);
+    
+    if (!$user) {
+      //User couldn't be loaded so skip it.
+      \Drupal::logger('unl_cas')->notice('UNL User data for ' . $data->uid . ' failed to update, user not found');
+      return;
+    }
+    
+    $result = $helper->updateUserData($user);
+    
+    if ($result) {
+      \Drupal::logger('unl_cas')->info('UNL User data for ' . $user->getAccountName() . ' updated');
+    } else {
+      \Drupal::logger('unl_cas')->notice('UNL User data for ' . $user->getAccountName() . ' failed to update');
+    }
+  }
+}

--- a/src/Plugin/QueueWorker/UpdateUserDataCron.php
+++ b/src/Plugin/QueueWorker/UpdateUserDataCron.php
@@ -16,6 +16,8 @@ use Drupal\user\Entity\User;
  */
 class UpdateUserDataCron extends QueueWorkerBase
 {
+  
+  protected $processedIds = [];
 
   /**
    * Works on a single queue item.
@@ -47,6 +49,14 @@ class UpdateUserDataCron extends QueueWorkerBase
     if (!isset($data->uid)) {
       return;
     }
+    
+    if (in_array($data->uid, $this->processedIds)) {
+      //We already processed this item during this cron, so skip it.
+      return;
+    }
+    
+    //Save this in the list of processed Ids
+    $this->processedIds[] = $data->uid;
     
     $helper = new Helper();
     $user = User::load($data->uid);

--- a/unl_cas.module
+++ b/unl_cas.module
@@ -8,3 +8,14 @@ function unl_cas_install() {
       ->set('register', USER_REGISTER_ADMINISTRATORS_ONLY)
       ->save(TRUE);
 }
+
+function unl_cas_user_login(\Drupal\Core\Session\AccountInterface $account) {
+  //Schedule a user data update for the account
+  /** @var \Drupal\Core\Queue\QueueFactory $queue_factory */
+  $queue_factory = \Drupal::service('queue');
+  /** @var \Drupal\Core\Queue\QueueInterface $queue */
+  $queue = $queue_factory->get('cron_unl_cas_update_user_data', true);
+  $item = new \stdClass();
+  $item->uid = $account->id();
+  $queue->createItem($item);
+}


### PR DESCRIPTION
This PR adds support for retrieving account data, such as the correct email address and primary affiliation. It tries to get the data from LDAP first, and falls back to directory data. See the readme for more info.

https://github.com/unlcms/UNL-CMS-2/issues/3

Note, we still need to implement an account search and import feature. But everything is set up now to make that pretty easy (crosses fingers)