### PR TITLE
UnlCasLoader::onRequest() should permit tests to access /user/login

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ The unl_cas module should ONLY add functionality to force authentication though 
 The reason for the separation is that twofold:
 * testing is impossible if we modify the core login routes (some tests depend on being able to create users and log them in via the cour authentication mechanism)
 * The authentication method for UNL might change (cas vs shib), while the user data importing should remain constant (or at least similar).
+
+The redirect behavior executed at '/user/login' can be disabled by setting an environment variable: 'UNLCAS_BYPASS_LOGIN_REDIRECT'.

--- a/src/EventSubscriber/UnlCasLoader.php
+++ b/src/EventSubscriber/UnlCasLoader.php
@@ -35,6 +35,10 @@ class UnlCasLoader implements EventSubscriberInterface {
 
     // Redirect the login form to CAS.
     if (\Drupal::service('path.current')->getPath() == '/user/login') {
+      // If login page is being accessed by tests, then don't redirect.
+      if (isset($_ENV['SIMPLETEST_BASE_URL'])) {
+        return;
+      }
       $response = new TrustedRedirectResponse($this->cas->getLoginUrl(), 302);
       $response->addCacheableDependency((new \Drupal\Core\Cache\CacheableMetadata())->setCacheMaxAge(0));
       $event->setResponse($response);

--- a/src/EventSubscriber/UnlCasLoader.php
+++ b/src/EventSubscriber/UnlCasLoader.php
@@ -35,8 +35,8 @@ class UnlCasLoader implements EventSubscriberInterface {
 
     // Redirect the login form to CAS.
     if (\Drupal::service('path.current')->getPath() == '/user/login') {
-      // If login page is being accessed by tests, then don't redirect.
-      if (isset($_ENV['SIMPLETEST_BASE_URL'])) {
+      // Allow redirect to be bypassed with environment variable.
+      if (isset($_ENV['UNLCAS_BYPASS_LOGIN_REDIRECT'])) {
         return;
       }
       $response = new TrustedRedirectResponse($this->cas->getLoginUrl(), 302);


### PR DESCRIPTION
[WebDriverTestBase](https://api.drupal.org/api/drupal/core%21tests%21Drupal%21FunctionalJavascriptTests%21WebDriverTestBase.php/class/WebDriverTestBase/8.6.x) needs access to the Drupal login form. Currently, when a test attempts to login, the test fails because it cannot access /user/login.

For example:

```
1) Drupal\Tests\layout_builder_restrictions\FunctionalJavascript\LayoutBuilderRestrictionsTest::testBlockRestriction
Behat\Mink\Exception\ElementNotFoundException: Form field with id|name|label|value "pass" not found.

/app/vendor/behat/mink/src/WebAssert.php:636
/app/web/core/tests/Drupal/Tests/UiHelperTrait.php:84
/app/web/core/tests/Drupal/Tests/UiHelperTrait.php:250
/app/web/modules/contrib/layout_builder_restrictions/tests/src/FunctionalJavascript/LayoutBuilderRestrictionsTest.php:35
```


We can determine if a test is being run by checking if $_ENV['SIMPLETEST_BASE_URL'] is set.

Proposed change:

```
      // Redirect the login form to CAS.
      if (\Drupal::service('path.current')->getPath() == '/user/login') {
+       // If login form is being accessed by tests, then don't redirect.
+       if (isset($_ENV['SIMPLETEST_BASE_URL'])) {
+         return;
+       }
        $response = new TrustedRedirectResponse($this->cas->getLoginUrl(), 302);
        $response->addCacheableDependency((new \Drupal\Core\Cache\CacheableMetadata())->setCacheMaxAge(0));
        $event->setResponse($response);
        return;
      }
```