### PR TITLE
Remove Deprecated code; prepare for D9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     }
   ],
   "require": {
+    "drupal/core": "^8 || ^9",
     "unlcms/unl_user": "dev-8.x-1.x"
   }
 }

--- a/src/Controller/UnlCasController.php
+++ b/src/Controller/UnlCasController.php
@@ -3,64 +3,56 @@
 namespace Drupal\unl_cas\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\RedirectDestination;
 use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\Core\Url;
+use Drupal\unl_cas\UnlCasAdapter;
 use Drupal\unl_user\Helper;
 use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class UnlCasController extends ControllerBase {
 
-  public $adapter;
+  /**
+   * A UNL CAS adapter.
+   *
+   * @var \Drupal\unl_cas\UnlCasAdapter
+   */
+  protected $unlCasAdapter;
 
-  static $zendLoaded = FALSE;
+  /**
+   * Provides helpers for redirect destinations.
+   *
+   * @var \Drupal\Core\Routing\RedirectDestination
+   */
+  protected $redirectDestination;
 
-  public function unl_load_zend_framework() {
-    if (UnlCasController::$zendLoaded) {
-      return;
-    }
-
-    set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__FILE__) . '/../../libraries');
-    require_once 'Zend/Loader/Autoloader.php';
-    $autoloader = \Zend_Loader_Autoloader::getInstance();
-    $autoloader->registerNamespace('Unl_');
-    UnlCasController::$zendLoaded = TRUE;
+  /**
+   * Constructs a UnlCasController object.
+   *
+   * @param \Drupal\unl_cas\UnlCasAdapter $unl_cas_adapter
+   *   A UNL CAS adapter.
+   * @param \Drupal\Core\Routing\RedirectDestination $redirect_destination
+   *   Provides helpers for redirect destinations.
+   */
+  public function __construct(UnlCasAdapter $unl_cas_adapter, RedirectDestination $redirect_destination) {
+    $this->unlCasAdapter = $unl_cas_adapter;
+    $this->redirectDestination = $redirect_destination;
   }
 
-  public function getAdapter() {
-    $this->unl_load_zend_framework();
-
-    /**
-     * @var \Symfony\Component\HttpFoundation\Session\Session $session
-     */
-    $session = \Drupal::service('session');
-
-    // Start the session because if drupal doesn't then Zend_Session will.
-    if (!$session->isStarted()) {
-      /**
-       * Drupal will start a 'lazy' session for anonymous users so that a cookie is not set (to help with things like varnish)
-       * We can't $session->start(), because it is already lazy-started
-       * Instead we need to migrate it to a stored (non-lazy) session
-       */
-      $session->migrate();
-    }
-
-    if (!$this->adapter) {
-      if (\Drupal::request()->isSecure()) {
-        $url = Url::fromRoute('unl_cas.validate', array(), array('absolute' => TRUE, 'query' => drupal_get_destination(), 'https' => TRUE))->toString();
-      } else {
-        $url = Url::fromRoute('unl_cas.validate', array(), array('absolute' => TRUE, 'query' => drupal_get_destination()))->toString();
-      }
-      $this->adapter = new \Unl_Cas($url, 'https://shib.unl.edu/idp/profile/cas');
-    }
-
-    \Drupal::request()->query->remove('destination');
-
-    return $this->adapter;
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('unl_cas.adapter'),
+      $container->get('redirect.destination')
+    );
   }
 
   public function validate() {
-    $cas = $this->getAdapter();
+    $cas = $this->unlCasAdapter->getAdapter();
 
     if (array_key_exists('logoutRequest', $_POST)) {
       $cas->handleLogoutRequest($_POST['logoutRequest']);
@@ -88,7 +80,7 @@ class UnlCasController extends ControllerBase {
       setcookie('unl_sso', 'fake', time() - 60 * 60 * 24, '/', '.unl.edu');
     }
 
-    $destination = drupal_get_destination();
+    $destination = $this->redirectDestination->getAsArray();
     if (!$destination['destination']) {
       $destination['destination'] = 'admin';
     }

--- a/src/EventSubscriber/UnlCasLoader.php
+++ b/src/EventSubscriber/UnlCasLoader.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\unl_cas\EventSubscriber;
 
-use Drupal\unl_cas\Controller\UnlCasController;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\unl_cas\UnlCasAdapter;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -17,6 +17,13 @@ class UnlCasLoader implements EventSubscriberInterface {
   protected $cas;
 
   /**
+   * A UNL CAS adapter.
+   *
+   * @var \Drupal\unl_cas\UnlCasAdapter
+   */
+  protected $unlCasAdapter;
+
+  /**
    * The currently active route match object.
    *
    * @var \Drupal\Core\Routing\RouteMatchInterface
@@ -24,11 +31,15 @@ class UnlCasLoader implements EventSubscriberInterface {
   protected $currentRouteMatch;
 
   /**
-   * Constructs a new UnlCasLoader.
+   * Constructs a new UnlCasLoader object.
    *
+   * @param \Drupal\unl_cas\UnlCasAdapter $unl_cas_adapter
+   *   A UNL CAS adapter.
    * @param \Drupal\Core\Routing\RouteMatchInterface $current_route_match
+   *   The currently active route match object.
    */
-  public function __construct(RouteMatchInterface $current_route_match) {
+  public function __construct(UnlCasAdapter $unl_cas_adapter, RouteMatchInterface $current_route_match) {
+    $this->unlCasAdapter = $unl_cas_adapter;
     $this->currentRouteMatch = $current_route_match;
   }
 
@@ -48,7 +59,7 @@ class UnlCasLoader implements EventSubscriberInterface {
       return;
     }
 
-    $this->cas = (new UnlCasController())->getAdapter();
+    $this->cas = $this->unlCasAdapter->getAdapter();
 
     // Redirect the login form to CAS.
     if ($this->currentRouteMatch->getRouteName() == 'user.login') {

--- a/src/UnlCasAdapter.php
+++ b/src/UnlCasAdapter.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\unl_cas;
+
+use Drupal\Core\Routing\RedirectDestination;
+use Drupal\Core\Url;
+
+/**
+ * Provides a UNL CAS adapter.
+ */
+class UnlCasAdapter {
+
+  /**
+   * UNL CAS adapter.
+   *
+   * @var \Unl_Cas
+   */
+  protected $adapter;
+
+  /**
+   * Whether or not Zend framework is loaded.
+   *
+   * @var bool
+   */
+  protected $zendLoaded;
+
+  /**
+   * Provides helpers for redirect destinations.
+   *
+   * @var \Drupal\Core\Routing\RedirectDestination
+   */
+  protected $redirectDestination;
+
+  /**
+   * Constructs a UnlCasAdapter object.
+   *
+   * @param \Drupal\Core\Routing\RedirectDestination $redirect_destination
+   *   Provides helpers for redirect destinations.
+   */
+  public function __construct(RedirectDestination $redirect_destination) {
+    $this->redirectDestination = $redirect_destination;
+    $this->zendLoaded = FALSE;
+  }
+
+  /**
+   * Loads the Zend framework if it's not already loaded.
+   */
+  public function loadZendFramework() {
+    if ($this->zendLoaded) {
+      return;
+    }
+
+    set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__FILE__) . '/../libraries');
+    require_once 'Zend/Loader/Autoloader.php';
+    $autoloader = \Zend_Loader_Autoloader::getInstance();
+    $autoloader->registerNamespace('Unl_');
+    $this->zendLoaded = TRUE;
+  }
+
+  /**
+   * Returns a UNL CAS adapter object.
+   *
+   * @return \Unl_Cas
+   *   A UNL CAS adapter object.
+   */
+  public function getAdapter() {
+    $this->loadZendFramework();
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\Session\Session $session
+     */
+    $session = \Drupal::service('session');
+
+    // Start the session because if drupal doesn't then Zend_Session will.
+    if (!$session->isStarted()) {
+      /**
+       * Drupal will start a 'lazy' session for anonymous users so that a cookie is not set (to help with things like varnish)
+       * We can't $session->start(), because it is already lazy-started
+       * Instead we need to migrate it to a stored (non-lazy) session
+       */
+      $session->migrate();
+    }
+
+    if (!$this->adapter) {
+      if (\Drupal::request()->isSecure()) {
+        $url = Url::fromRoute('unl_cas.validate', array(), array('absolute' => TRUE, 'query' => $this->redirectDestination->getAsArray(), 'https' => TRUE))->toString();
+      } else {
+        $url = Url::fromRoute('unl_cas.validate', array(), array('absolute' => TRUE, 'query' => $this->redirectDestination->getAsArray()))->toString();
+      }
+      $this->adapter = new \Unl_Cas($url, 'https://shib.unl.edu/idp/profile/cas');
+    }
+
+    \Drupal::request()->query->remove('destination');
+
+    return $this->adapter;
+  }
+
+}

--- a/unl_cas.info.yml
+++ b/unl_cas.info.yml
@@ -3,7 +3,7 @@ description: 'Enables CAS authentication/registration of users through login.unl
 package: UNL
 
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 
 version: 1.x
 

--- a/unl_cas.module
+++ b/unl_cas.module
@@ -1,13 +1,15 @@
 <?php
 
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Url;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_install().
  */
 function unl_cas_install() {
   \Drupal::configFactory()->getEditable('user.settings')
-      ->set('register', USER_REGISTER_ADMINISTRATORS_ONLY)
+      ->set('register', UserInterface::REGISTER_ADMINISTRATORS_ONLY)
       ->save(TRUE);
 }
 
@@ -29,8 +31,10 @@ function unl_cas_user_login(\Drupal\Core\Session\AccountInterface $account) {
  * Implements hook_user_logout().
  */
 function unl_cas_user_logout($account) {
-  $cas = (new \Drupal\unl_cas\Controller\UnlCasController())->getAdapter();
-  $url = $cas->getLogoutUrl(\Drupal::url('<front>', [], ['absolute' => TRUE]));
+  $unl_cas_loader = \Drupal::service('unl_cas.adapter');
+  $cas = $unl_cas_loader->getAdapter();
+  $url = $cas->getLogoutUrl(Url::fromRoute('<front>', [], ['absolute' => TRUE]));
+
   $response = new TrustedRedirectResponse($url, 302);
   $response->addCacheableDependency((new \Drupal\Core\Cache\CacheableMetadata())->setCacheMaxAge(0));
   $response->send();

--- a/unl_cas.services.yml
+++ b/unl_cas.services.yml
@@ -1,6 +1,9 @@
 services:
+  unl_cas.adapter:
+    class: '\Drupal\unl_cas\UnlCasAdapter'
+    arguments: ['@redirect.destination']
   unL_cas_loader:
     class: '\Drupal\unl_cas\EventSubscriber\UnlCasLoader'
-    arguments: ['@current_route_match']
+    arguments: ['@unl_cas.adapter', '@current_route_match']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
Prepare for D9
- Remove deprecated code
- Update composer.json
- Update *.info.yml

Drupal-check results:

```
$ drupal-check unl_cas.*
 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------- 
  Line   unl_cas.module                                                        
 ------ ---------------------------------------------------------------------- 
  10     Call to deprecated constant USER_REGISTER_ADMINISTRATORS_ONLY:        
         Deprecated in drupal:8.3.0 and is removed from drupal:9.0.0. Use      
         \Drupal\user\UserInterface::REGISTER_ADMINISTRATORS_ONLY instead.     
  33     Call to deprecated method url() of class Drupal:                      
         in drupal:8.0.0 and is removed from drupal:9.0.0.                     
         Instead create a \Drupal\Core\Url object directly, for example using  
         Url::fromRoute().                                                     
 ------ ---------------------------------------------------------------------- 

                                                                                
 [ERROR] Found 2 errors                                                         
                                                                                
$ drupal-check src/
 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------- 
  Line   Controller/UnlCasController.php                        
 ------ ------------------------------------------------------- 
  50     Call to deprecated function drupal_get_destination():  
         in drupal:8.0.0 and is removed from drupal:9.0.0.      
         Use the redirect.destination service.                  
  52     Call to deprecated function drupal_get_destination():  
         in drupal:8.0.0 and is removed from drupal:9.0.0.      
         Use the redirect.destination service.                  
  91     Call to deprecated function drupal_get_destination():  
         in drupal:8.0.0 and is removed from drupal:9.0.0.      
         Use the redirect.destination service.                  
 ------ ------------------------------------------------------- 

                                                                                
 [ERROR] Found 3 errors                                                         
                                                                                

```