### PR TITLE
Change composer.json requirement for unlcms/unl_user

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
   ],
   "require": {
     "drupal/core": "^8 || ^9",
-    "unlcms/unl_user": "dev-8.x-1.x"
+    "unlcms/unl_user": "^1.0"
   }
 }


### PR DESCRIPTION
Currently, composer.json requires `"unlcms/unl_user": "dev-8.x-1.x"`. With the move to semvar, this should be changed to `"unlcms/unl_user": "^1.0"`.