### PR TITLE
unl_cas_user_logout() should pass URL string, not URL object, to $cas->getLogoutUrl()

### DIFF
--- a/unl_cas.module
+++ b/unl_cas.module
@@ -33,7 +33,7 @@ function unl_cas_user_login(\Drupal\Core\Session\AccountInterface $account) {
 function unl_cas_user_logout($account) {
   $unl_cas_loader = \Drupal::service('unl_cas.adapter');
   $cas = $unl_cas_loader->getAdapter();
-  $url = $cas->getLogoutUrl(Url::fromRoute('<front>', [], ['absolute' => TRUE]));
+  $url = $cas->getLogoutUrl(Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString());
 
   $response = new TrustedRedirectResponse($url, 302);
   $response->addCacheableDependency((new \Drupal\Core\Cache\CacheableMetadata())->setCacheMaxAge(0));


### PR DESCRIPTION
Currently, `unl_cas_user_logout()` passes a `URL` object to `$cas->getLogoutUrl()` instead of a URL string, which is expected.

This results in the following warning message on logout:

```php
Warning: urlencode() expects parameter 1 to be string, object given in Unl_Cas->getLogoutUrl() (line 271 of /var/www/html/web/modules/contrib/unl_cas/libraries/Unl/Cas.php)
```

Proposed solution:
Use the `toString()` method on the `URL` object before calling `$cas->getLogoutUrl()`.
